### PR TITLE
Google SSO ByPass for Android with Mock User

### DIFF
--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -3,6 +3,8 @@ import { Divider } from "@/components/ui/divider";
 import {
   getGoogleAuthRequest,
   handleGoogleSignIn,
+  handleMockSignIn,
+  isAndroid,
 } from "@/services/auth-service/google-auth";
 import { LinearGradient } from "expo-linear-gradient";
 import * as WebBrowser from "expo-web-browser";
@@ -25,6 +27,14 @@ export default function Login() {
       });
     }
   }, [response]);
+
+  const handleGoogleSSO = () => {
+    if (isAndroid) {
+      handleMockSignIn();
+    } else {
+      promptAsync();
+    }
+  };
 
   return (
     <LinearGradient colors={["#F1FDFF", "#DCFBFF"]} style={{ flex: 1 }}>
@@ -74,7 +84,7 @@ export default function Login() {
             action="secondary"
             className="bg-white border border-gray-300 w-full rounded-sm my-4 h-14"
             disabled={!request}
-            onPress={() => promptAsync()}
+            onPress={handleGoogleSSO}
           >
             <View className="flex-row items-center px-4 w-full">
               <Image

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,9 @@
 import { Spinner } from "@/components/ui/spinner";
-import { hasStoredSession } from "@/services/auth-service/google-auth";
+import {
+  getUserFromStorage,
+  hasStoredSession,
+  isAndroid,
+} from "@/services/auth-service/google-auth";
 import { RESET_ONBOARDING } from "@/utils/config";
 import { ROUTES } from "@/utils/route";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -18,7 +22,10 @@ export default function Index() {
           (await AsyncStorage.setItem("isFirstLaunch", "false"));
 
         const isFirstLaunch = await AsyncStorage.getItem("isFirstLaunch");
-        const valid = await hasStoredSession();
+
+        const valid = await (isAndroid
+          ? !!getUserFromStorage()
+          : hasStoredSession());
 
         if (isFirstLaunch === null || isFirstLaunch === "false") {
           setRedirectTo(ROUTES.LAUNCH);

--- a/app/myhealth/home.tsx
+++ b/app/myhealth/home.tsx
@@ -1,14 +1,17 @@
-import React, { useEffect, useState } from "react";
-import { View, Text, Image, Button } from "react-native";
-import { router } from "expo-router";
 import {
+  initializeMockSession,
   initializeSession,
+  isAndroid,
   signOut,
 } from "@/services/auth-service/google-auth";
 import { Patient, User } from "@/services/database/migrations/v1/schema_v1";
-import { useSQLiteContext } from "expo-sqlite";
-import { UserModel } from "@/services/database/models/UserModel";
 import { PatientModel } from "@/services/database/models/PatientModel";
+import { UserModel } from "@/services/database/models/UserModel";
+import { logger } from "@/services/logging/logger";
+import { router } from "expo-router";
+import { useSQLiteContext } from "expo-sqlite";
+import React, { useEffect, useState } from "react";
+import { Button, Image, Text, View } from "react-native";
 
 const Home = () => {
   const [user, setUser] = useState<User | null>(null);
@@ -20,8 +23,13 @@ const Home = () => {
   const patientModel = new PatientModel(db);
 
   useEffect(() => {
-    console.log(`DB Path : "${db.databasePath}"`);
-    initializeSession(setUser).finally(() => setLoading(false));
+    logger.debug(`DB Path : "${db.databasePath}"`);
+    if (isAndroid) {
+      console.log("Android? :", isAndroid);
+      initializeMockSession(setUser).finally(() => setLoading(false));
+    } else {
+      initializeSession(setUser).finally(() => setLoading(false));
+    }
   }, []);
 
   useEffect(() => {
@@ -90,7 +98,14 @@ const Home = () => {
   }
 
   return (
-    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+    <View
+      style={{
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 5,
+      }}
+    >
       <Image
         source={{ uri: user.picture }}
         style={{ width: 100, height: 100, borderRadius: 50 }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-font": "~13.3.1",
         "expo-linear-gradient": "~14.1.4",
         "expo-linking": "~7.1.4",
+        "expo-media-library": "~17.1.6",
         "expo-router": "~5.0.5",
         "expo-secure-store": "~14.2.3",
         "expo-splash-screen": "~0.30.8",
@@ -6344,6 +6345,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-media-library": {
+      "version": "17.1.6",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.1.6.tgz",
+      "integrity": "sha512-Py8Y9wJlNXBZkhtJYy9acj0oRoUV09WXsZnjcvy6xZjpniPQIq0wkIkgS2DLhlYmMdjBrSux2TGp7Omi2WHp1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "tailwindcss": "^3.4.17",
     "expo-auth-session": "~6.1.5",
     "expo-sqlite": "~15.2.10",
-    "expo-file-system": "~18.1.10"
+    "expo-file-system": "~18.1.10",
+    "expo-media-library": "~17.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/auth-service/google-auth.ts
+++ b/services/auth-service/google-auth.ts
@@ -1,11 +1,13 @@
+import { AuthTokens } from "@/services/common/types";
+import { logger } from "@/services/logging/logger";
+import { googleConfig, TOKEN_EXPIRY } from "@/utils/config";
+import MOCK_USER from "@/utils/mock-user";
+import { ROUTES } from "@/utils/route";
+import { AuthSessionResult } from "expo-auth-session";
+import * as Google from "expo-auth-session/providers/google";
+import { router } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";
-import { AuthTokens } from "@/services/common/types";
-import { googleConfig, TOKEN_EXPIRY } from "@/utils/config";
-import * as Google from "expo-auth-session/providers/google";
-import { AuthSessionResult } from "expo-auth-session";
-import { router } from "expo-router";
-import { logger } from "@/services/logging/logger";
 import { User } from "../database/migrations/v1/schema_v1";
 
 
@@ -253,4 +255,34 @@ export const startSession = async (): Promise<boolean> => {
     }
 
     return false;
+};
+
+// --------- Mock Session
+
+export const isAndroid = Platform.OS === "android";
+
+export const handleMockSignIn = async () => {
+    console.log("🤖 Android emulator detected — skipping SSO and using mock user");
+
+    await saveUser(MOCK_USER);
+    const keys = ["access_token", "refresh_token", "issued_at", "expires_in"];
+    await Promise.all(keys.map((key) => SecureStore.deleteItemAsync(key)));
+    logger.debug("Tokens cleared.");
+    router.replace(ROUTES.MYHEALTH);
+};
+
+export const initializeMockSession = async (
+    setUser: (user: User | null) => void
+): Promise<void> => {
+
+    const storedUser = await getUserFromStorage();
+    if (storedUser) {
+        logger.debug("👤 Loaded user:", storedUser.email);
+        setUser(storedUser);
+    } else {
+        console.warn("❌ User data missing. Signing out...");
+        await signOut();
+        router.replace("/auth/login");
+    }
+
 };

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,7 +1,7 @@
 import { GoogleConfig } from "@/services/common/types";
 
 
-export const DEBUG_ON = false;
+export const DEBUG_ON = true;
 
 export const RESET_ONBOARDING = false;
 

--- a/utils/mock-user.ts
+++ b/utils/mock-user.ts
@@ -1,0 +1,8 @@
+const MOCK_USER = {
+    id: '116238727817152771287',
+    email: "dev.mock.user@email.com",
+    name: "Dev.Mock",
+    picture: "https://ui-avatars.com/api/?name=Dev+Mock&background=49AFBE&color=FEFEFF"
+};
+
+export default MOCK_USER;


### PR DESCRIPTION
This PR introduces a mechanism to bypass Google SSO for Android emulator using Mock User data.

**Key changes :**
- Added `mock-user.ts` file which defines the static mock user profile
- The token authentication is now skipped & user can continue accessing the app with this Mock User.

**Demo :** 

[GoogleSSO-Bypass-Android.webm](https://github.com/user-attachments/assets/97904cdb-3085-43da-95d2-42e4c7524e15)
