### PR TITLE
Hot Fix : Fix seed data insertion by enabling foreign keys after migrations

### DIFF
--- a/services/database/db.ts
+++ b/services/database/db.ts
@@ -19,7 +19,6 @@ const dbReadyPromise = new Promise<SQLiteDatabase>((resolve) => {
 export const initializeDatabase = async (db: SQLiteDatabase): Promise<void> => {
     await handleAndroidDBReset(DB_NAME);
     _db = db;
-    await _db.execAsync("PRAGMA foreign_keys = ON;");
     dbReadyResolver?.(db);
     logger.debug(`DB Path: "${_db.databasePath}"`);
     await runMigrations(_db);
@@ -57,4 +56,6 @@ export const runMigrations = async (db: SQLiteDatabase): Promise<void> => {
             await db.execAsync(`PRAGMA user_version = ${DB_VERSION}`);
         });
     }
+
+    await db.execAsync("PRAGMA foreign_keys = ON;");
 };


### PR DESCRIPTION
### Bug :
- On fresh installs, the seed data from `seed_v1` and `seed_track_v1` was not being inserted into the SQLite database.
---
### Problem Fixed :
- Seed data was not being inserted due to premature FK enforcement.
- Updated `runMigrations` in `db.ts`.
- `PRAGMA foreign_keys = ON;` now runs after schema + seed data creation.
- Verified seed data loads successfully on fresh installs.